### PR TITLE
Improved jBeacon compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Virtual Cohort Assembly Discovery Phase Report: National Community Needs & Candi
 
 ## Implementations
 
+We are investigating 2 Beacon v2 implementations as follows.
+
 ### Serverless Beacon
 
 - See https://github.com/umccr/sbeacon-exploration

--- a/compose_stack/README.md
+++ b/compose_stack/README.md
@@ -1,6 +1,8 @@
 # Beacon Compose Stack
 
-Terraform-based VM instance provisioning on AWS for hosting Java Beacon [docker compose stack](../beacon).
+_(aka jBeacon)_
+
+Terraform-based VM instance provisioning on AWS for hosting Java Beacon [docker compose stack](../beacon) _(also known as jBeacon stack)_.
 
 ## Prerequisite
 
@@ -49,7 +51,7 @@ terraform apply
 ```
 aws ssm start-session --target i-1234561117085dce1
 sudo su - root
-lsblk | grep 300G
+lsblk
 ll /dev/nvme1n1
 mkfs -t xfs /dev/nvme1n1
 blkid | grep nvme1n1

--- a/compose_stack/ec2.tf
+++ b/compose_stack/ec2.tf
@@ -31,12 +31,12 @@ module "beacon_compose_instance" {
   name                        = "JavaBeaconInstance"
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = var.instance_type
-  hibernation                 = true
+  hibernation                 = var.hibernation
   associate_public_ip_address = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM Role for Java Beacon EC2 Instance"
   iam_role_policies           = {
-    AdministratorAccess = "arn:aws:iam::aws:policy/AdministratorAccess"
+    AdministratorAccess = "arn:aws:iam::aws:policy/AdministratorAccess"  # FIXME this may be too high for PROD env
   }
 
   vpc_security_group_ids = [aws_security_group.beacon_compose_instance_sg.id]

--- a/compose_stack/main.tf
+++ b/compose_stack/main.tf
@@ -23,8 +23,8 @@ provider "aws" {
 }
 
 locals {
-  stack_name_dash = "beacon-compose"
-  stack_name_us   = "beacon_compose"
+  stack_name_dash = "jBeacon"
+  stack_name_us   = "jBeacon"
 }
 
 data "aws_route53_zone" "selected" {
@@ -52,7 +52,8 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    # pinned AMI
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230112"]
   }
 
   filter {

--- a/compose_stack/terraform.tfvars.sample
+++ b/compose_stack/terraform.tfvars.sample
@@ -6,3 +6,4 @@ app_domain = "beacon.umccr.org"
 instance_type = "t3.large"
 root_disk_size = 10
 data_disk_size = 150
+hibernation = false

--- a/compose_stack/variables.tf
+++ b/compose_stack/variables.tf
@@ -11,7 +11,7 @@ variable "app_domain" {
 }
 
 variable "instance_type" {
-  default = "t3.large"  # 2 vCPU, 8GB MEM
+  default = "r6i.large"  # 2 vCPU, 16GB MEM
 }
 
 variable "root_disk_size" {
@@ -19,5 +19,9 @@ variable "root_disk_size" {
 }
 
 variable "data_disk_size" {
-  default = 300  # in GB
+  default = 500  # in GB
+}
+
+variable "hibernation" {
+  default = false
 }


### PR DESCRIPTION
* Renamed to jBeacon stack
* Adjusted to r6 for more mem
* Pinned Ubuntu AMI
* Disabled hibernation by default
  as hibernation can't scale up without tearing down the instance
